### PR TITLE
Use --datadir instead of the --ldata alias

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -137,7 +137,7 @@ if ["default", "primary", "secondary"].include? payload[:member][:role]
     })
   end
 
-  execute 'mysql_install_db --basedir=/data --ldata=/data/var/db/mysql --user=gonano --defaults-file=/data/etc/my.cnf' do
+  execute 'mysql_install_db --basedir=/data --datadir=/data/var/db/mysql --user=gonano --defaults-file=/data/etc/my.cnf' do
     user 'gonano'
     not_if { ::Dir.exists? '/data/var/db/mysql/mysql' }
   end


### PR DESCRIPTION
The `--datadir` alias, `--ldata`, for use with `mysql_install_db`, has been removed in MySQL 5.7.5.  Since all versions of MySQL from 5.5 through 5.7.19 (the current latest version) support `--datadir`, switch to it instead.  This should allow `nanobox/mysql:5.7-beta` images to properly configure and boot, while not affecting other images.